### PR TITLE
Add calcLinearIntersection method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-MANIFEST 
+MANIFEST
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -106,3 +106,6 @@ venv.bak/
 # Misc
 *.swp
 compiledUI/
+
+# editor configs
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.pythonPath": "env/bin/python3"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "python.pythonPath": "env/bin/python3"
-}

--- a/methods/linear/calcLinear.py
+++ b/methods/linear/calcLinear.py
@@ -1,3 +1,5 @@
+import math
+
 class Linear:
 
     def __init__(self, a, c, length):
@@ -7,3 +9,23 @@ class Linear:
 
     def calc_linear_line(self):
         print([(0 - self.length, self.a * (0 - self.length)), (0 - self.length, self.a * self.length)])
+
+    def calcLineaIntersection(self, line):
+        """
+        This function accepts one line of Linear class
+        and returns the coordinates of intersection between the self and the line passed
+
+        If there is no intercept it returns 0
+        If there are infinite intercepts it return math.inf
+        If there is one unique intercept it returns a tuple with (x, y)
+        """
+
+        if self.a == line.a:
+            if self.c == line.c:
+                return math.inf
+            return 0
+
+        x = (line.c-self.c)/(self.a - line.a)
+        y = self.a*(line.c - self.c)/(self.a - line.a) + self.c
+
+        return (x, y)

--- a/methods/linear/calcLinearIntercept.py
+++ b/methods/linear/calcLinearIntercept.py
@@ -1,0 +1,21 @@
+import math
+
+def calcLinearIntersection(line1, line2):
+    """
+    This function accepts two lines of Linear class
+    and returns the coordinates of intersection between the two lines
+
+    If there is no intercept it returns 0
+    If there are infinite intercepts it return math.inf
+    If there is one unique intercept it returns a tuple with (x, y)
+    """
+
+    if line1.a == line2.a:
+        if line1.c == line2.c:
+            return math.inf
+        return 0
+
+    x = (line2.c-line1.c)/(line1.a - line2.a)
+    y = line1.a*(line2.c - line1.c)/(line1.a - line2.a) + line1.c
+
+    return (x, y)


### PR DESCRIPTION
This method calculates the intersection point between two Lines. This
method returns the coordinates of intersection if there is a unique
point, 0 if there are none, and math.inf if the lines coincide.

I have changed the name of the method from calcLinearIntercept to calcLinearIntersection to make it clear that we calculate the intersection point between two lines.

I have added two methods, one is standalone and takes in two Linear objects, the other is a method of the class Linear and calculates the intersection point between self and the line passed.

This fixes #20 